### PR TITLE
Fix issue with Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ ENV PATH $PATH:$GOROOT/bin:$GOPATH/bin
 
 WORKDIR /distributive
 ADD . /distributive
-RUN go build /distributive/distributive.go
+RUN go build .
 
 CMD [/distributive/distributive -f /distributive/samples/filesystem.json]


### PR DESCRIPTION
distributive.go was renamed to main.go and we shouldn't pass it to
the go build command, as it results in dependencies problems.