### PR TITLE
The build instructions were different from the last version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ Installation/Building
 ---------------------
 To install the development version (potentially unstable):
  1. Clone this repo: `git clone https://github.com/CiscoCloud/distributive`
- 2. Get some dependancies: `go get github.com/CiscoCloud/distributive/workers && go get github.com/CiscoCloud/distributive/wrkutils`.
- 3. `go build`
- 4. Follow the "Usage" instructions below
+ 2. Install godep: `go get github.com/tools/godep`
+ 3. Get some dependancies: `go get github.com/CiscoCloud/distributive/workers && go get github.com/CiscoCloud/distributive/wrkutils`.
+ 4. Build it with: `go build`
+ 5. Follow the "Usage" instructions below
 
 We also provide premade RPM packages on [Bintray][bintray] for versioned
 releases. You can view the RPM source and build RPM snapshots at

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ Installation/Building
 ---------------------
 To install the development version (potentially unstable):
  1. Clone this repo: `git clone https://github.com/CiscoCloud/distributive`
- 2. Build a binary with `./build.sh`
- 3. Follow the "Usage" instructions below
+ 2. Get some dependancies: `go get github.com/CiscoCloud/distributive/workers && go get github.com/CiscoCloud/distributive/wrkutils`.
+ 3. `go build`
+ 4. Follow the "Usage" instructions below
 
 We also provide premade RPM packages on [Bintray][bintray] for versioned
 releases. You can view the RPM source and build RPM snapshots at


### PR DESCRIPTION
It's a small patch but it might be helpful to others.

There may also be another way to build - but this way worked just fine tonight on Linux and OS X.