### PR TITLE
Udp parsing working

### DIFF
--- a/tabular/tabular.go
+++ b/tabular/tabular.go
@@ -263,6 +263,19 @@ func GetColumnNoHeader(col int, tab Table) Column {
 	return column[1:]
 }
 
+
+// GetAllNoHeader safely removes the header
+func GetAllNoHeader(tab Table) (column Column) {
+	for _,line := range tab {
+		str_line := ""
+		for _,inside_line := range line {
+			str_line = str_line + inside_line
+		}
+		column = append(column, str_line)
+	}
+	return column[1:]
+}
+
 // GetColumnByHeader returns the body of a column with a header that is equal
 // to name (ignoring case differences). It is for developer ease and
 // future-proofing, as it doesn't rely on an index.

--- a/workers/network.go
+++ b/workers/network.go
@@ -24,7 +24,7 @@ func port(parameters []string) (exitCode int, exitMessage string) {
 			table := tabular.ProbabalisticSplit(data)
 			// TODO by header isn't working
 			//localAddresses := tabular.GetColumnByHeader("local_address", table)
-			localAddresses := tabular.GetColumnNoHeader(1, table)
+			localAddresses := tabular.GetAllNoHeader(table)
 			portRe := regexp.MustCompile(`([0-9A-F]{8}):([0-9A-F]{4})`)
 			for _, address := range localAddresses {
 				port := portRe.FindString(address)


### PR DESCRIPTION
Port when the ports are udp was not working.
It seems the method tabular.GetColumnNoHeader doesn't not have the same
behaviour with tcp or udp ports, so we have implemented GetAllNoHeader
that gives all the data without the header.
It works because to find the ports it's implemented with a regular
expression that it works finding in all the text