### PR TITLE
Fix typo in CanConnect

### DIFF
--- a/netstatus/netstatus.go
+++ b/netstatus/netstatus.go
@@ -174,7 +174,7 @@ func CanConnect(host string, protocol string, timeout time.Duration) bool {
 	}
 	// if a duration was specified, use it
 	if nanoseconds > 0 {
-		conn, err = net.DialTimeout("protocol", timeoutAddress, timeout)
+		conn, err = net.DialTimeout(protocol, timeoutAddress, timeout)
 		if conn != nil {
 			defer conn.Close()
 		}


### PR DESCRIPTION
Use value of a variable, not the variable name as a string